### PR TITLE
[3/4] Settings: wifi: Allow configuration of country code for wifi

### DIFF
--- a/res/values/custom_arrays.xml
+++ b/res/values/custom_arrays.xml
@@ -180,4 +180,34 @@
         <item>@string/app_ops_categories_bootup</item>
     </string-array>
 
+    <!-- Wi-Fi settings. Presented as a list dialog to the user to choose the Wi-Fi region code. -->
+    <string-array name="wifi_countrycode_entries">
+        <item>United States</item>
+        <item>Canada, Taiwan</item>
+        <item>Germany</item>
+        <item>Europe</item>
+        <item>Japan, Russia</item>
+        <item>Australia</item>
+        <item>Indonesia</item>
+        <item>China</item>
+        <item>Korea</item>
+        <item>Turkey</item>
+        <item>Singapore</item>
+        <item>Brazil</item>
+    </string-array>
+
+    <string-array name="wifi_countrycode_values" translatable="false">
+        <item>US</item>
+        <item>CA</item>
+        <item>DE</item>
+        <item>GB</item>
+        <item>JP</item>
+        <item>AU</item>
+        <item>ID</item>
+        <item>CN</item>
+        <item>KR</item>
+        <item>TR</item>
+        <item>SG</item>
+        <item>BR</item>
+    </string-array>
 </resources>

--- a/res/values/custom_strings.xml
+++ b/res/values/custom_strings.xml
@@ -234,4 +234,13 @@
     <string name="app_ops_permissions_always_ask">Always ask</string>
 
     <string name="interface_bars_title">Bars</string>
+
+    <!-- Wi-Fi settings screen, advanced, title for setting the wifi region code. -->
+    <string name="wifi_setting_countrycode_title">Wi-Fi region code</string>
+    <!-- Wi-Fi settings screen, setting summary for setting the wifi region code [CHAR LIMIT=50]-->
+    <string name="wifi_setting_countrycode_summary">Specify the region code for Wi-Fi</string>
+    <!-- Wi-Fi settings screen, error message when the region code could not be set [CHAR LIMIT=50]. -->
+    <string name="wifi_setting_countrycode_error">There was a problem setting the region code.</string>
+    <string name="wifi_setting_countrycode_default">Default</string>
+
 </resources>

--- a/res/xml/wifi_advanced_settings.xml
+++ b/res/xml/wifi_advanced_settings.xml
@@ -52,6 +52,15 @@
             android:entries="@array/wifi_frequency_band_entries"
             android:entryValues="@array/wifi_frequency_band_values" />
 
+    <ListPreference
+            android:key="wifi_countrycode"
+            android:title="@string/wifi_setting_countrycode_title"
+            android:summary="@string/wifi_setting_countrycode_summary"
+            android:persistent="false"
+            android:entries="@array/wifi_countrycode_entries"
+            android:entryValues="@array/wifi_countrycode_values"
+            />
+
     <Preference
             android:key="install_credentials"
             android:title="@string/wifi_install_credentials"


### PR DESCRIPTION
Wifi country code handling is a nightmare - Most retail devices
have region customization in /system for each country a device
is shipped to.
This doesn't work very well for a firmware like Cyanogenmod,
where we try to support all target countries with one firmware
package.  For whatever reason, with newer Broadcom drivers/
firmware blobs, the old trick of using a universal region code
(ccode=ALL in nvram_net.txt) does not seem to work.  Who knows
what the deal is for other wifi chipsets.
The good thing is that wpa_supplicant has a standardized
cross-chipset method for setting the region code, and we
use that here.

Change-Id: I615f0e0b2360e364cf185ec35a08d7a8522ed126